### PR TITLE
feat(usr): Add vault crypting layer support

### DIFF
--- a/cyclosible/Cyclosible/settings.py
+++ b/cyclosible/Cyclosible/settings.py
@@ -156,7 +156,26 @@ SECRET_KEY = 'll=1_7y5i4e!5)@g+25ouhhz2kru6d=15twq5c)faerhj5x^@9'
 # Trailing slash is needed here
 PLAYBOOK_PATH = "/home/<playbook-path>/"
 
-PLUGINS_ENABLED = ['s3']
+STORAGE_ENABLED = ['s3']
+
+# Can be 'password', 'file' or 'hashicorp'.
+# The hashicorp plugin will request the password in hashicorp's vault
+# Let this variable to None to disable vault password
+# Uncomment VAULT_* variables to configure the plugins
+# As it's a python file, you can also use os.environ to get the
+# value from your environment
+
+VAULT_ENABLED = None
+# VAULT_PASSWORD = "XXXXXXXX"
+# VAULT_FILE = "/home/<vault_password_path>"
+# VAULT_HASHICORP = {
+#     'scheme': 'https',
+#     'host': 'vault.company.com',
+#     'port': 8200,
+#     'token': 'xxxxxxxxxxxxxxxxx',
+#     'secret_path': 'cycloid/ansible',
+#     'secret_field': 'value'
+# }
 
 S3_BUCKET = "cycloid-cyclosible"
 S3_ACCESS_KEY = "XXXXXXXXXXX"

--- a/cyclosible/playbook/plugins/storage/base.py
+++ b/cyclosible/playbook/plugins/storage/base.py
@@ -8,14 +8,14 @@ logger = logging.getLogger(__name__)
 
 
 def check_plugin_enabled(plugin):
-    if plugin.name in settings.PLUGINS_ENABLED:
+    if plugin.name in settings.STORAGE_ENABLED:
         return True
     else:
         return False
 
 
 @six.add_metaclass(abc.ABCMeta)
-class PluginBase(object):
+class StorageBase(object):
     """Base class for Cyclosible plugin
     """
 

--- a/cyclosible/playbook/plugins/storage/s3.py
+++ b/cyclosible/playbook/plugins/storage/s3.py
@@ -1,10 +1,10 @@
-from .base import PluginBase
+from .base import StorageBase
 from django.conf import settings
 from boto.s3.key import Key
 import boto
 
 
-class S3Plugin(PluginBase):
+class S3Plugin(StorageBase):
     def __init__(self, task_id):
         super(S3Plugin, self).__init__(task_id)
         self.s3_connection = boto.connect_s3(aws_access_key_id=settings.S3_ACCESS_KEY,

--- a/cyclosible/playbook/plugins/vault/base.py
+++ b/cyclosible/playbook/plugins/vault/base.py
@@ -1,0 +1,19 @@
+import abc
+import six
+import logging
+logger = logging.getLogger(__name__)
+
+
+@six.add_metaclass(abc.ABCMeta)
+class VaultBase(object):
+    """Base class for Cyclosible vault plugin
+    """
+
+    def __init__(self):
+        self.vault_password = None
+
+    @abc.abstractmethod
+    def get_password(self):
+        """Get the ansible vault password.
+        :returns: String
+        """

--- a/cyclosible/playbook/plugins/vault/file.py
+++ b/cyclosible/playbook/plugins/vault/file.py
@@ -1,0 +1,9 @@
+from .base import VaultBase
+from django.conf import settings
+
+
+class FilePlugin(VaultBase):
+    def get_password(self):
+        with open(settings.VAULT_FILE) as vaultfile:
+            self.vault_password = vaultfile.read()
+            return self.vault_password

--- a/cyclosible/playbook/plugins/vault/hashicorp.py
+++ b/cyclosible/playbook/plugins/vault/hashicorp.py
@@ -1,0 +1,19 @@
+from .base import VaultBase
+from django.conf import settings
+import hvac
+
+
+class HashicorpPlugin(VaultBase):
+    def get_password(self):
+        client = hvac.Client(
+            url='{scheme}://{host}:{port}'.format(
+                scheme=settings.VAULT_HASHICORP.get('scheme'),
+                host=settings.VAULT_HASHICORP.get('host'),
+                port=settings.VAULT_HASHICORP.get('port'),
+            ),
+            token=settings.VAULT_HASHICORP.get('token')
+        )
+        self.vault_password = client.read(
+            settings.VAULT_HASHICORP.get('secret_path')
+        ).get('data').get(settings.VAULT_HASHICORP.get('secret_field'))
+        return self.vault_password

--- a/cyclosible/playbook/plugins/vault/password.py
+++ b/cyclosible/playbook/plugins/vault/password.py
@@ -1,0 +1,8 @@
+from .base import VaultBase
+from django.conf import settings
+
+
+class PasswordPlugin(VaultBase):
+    def get_password(self):
+        self.vault_password = settings.VAULT_PASSWORD
+        return self.vault_password

--- a/cyclosible/playbook/tasks.py
+++ b/cyclosible/playbook/tasks.py
@@ -1,20 +1,19 @@
-import json
-
 from django.contrib.auth.models import User
 from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.utils import timezone
 from stevedore import enabled, driver
-import ansible.playbook
-import ansible.utils.template
 from ..Cyclosible.celery import app
 from .models import Playbook
 from .plugins.storage.base import check_plugin_enabled
-from cyclosible.playbook.callbacks_ansiblev1 import PlaybookCallbacks, PlaybookRunnerCallbacks
+from .callbacks_ansiblev1 import PlaybookCallbacks, PlaybookRunnerCallbacks
 from .models import PlaybookRunHistory
 from ansible import errors
 from ansible import callbacks
 from ansible import utils
+import json
+import ansible.playbook
+import ansible.utils.template
 
 logger = get_task_logger(__name__)
 
@@ -51,6 +50,11 @@ def run_playbook(self, playbook_name, user_name, only_tags=None, skip_tags=None,
             vault_password = self.mgr_vault.driver.get_password()
         except RuntimeError as e:
             logger.error(e)
+
+        logger.debug('LOADED VAULT: {plugins} | Status: {status}'.format(
+            plugins=settings.VAULT_ENABLED,
+            status='OK' if vault_password else 'KO'
+        ))
 
     # Here, we override the default ansible callbacks to pass our customs parameters
     stats = callbacks.AggregateStats()

--- a/cyclosible/playbook/views.py
+++ b/cyclosible/playbook/views.py
@@ -53,7 +53,8 @@ class PlaybookViewSet(viewsets.ModelViewSet):
                                 status=status.HTTP_403_FORBIDDEN
                             )
                     else:
-                        only_tags = playbook.only_tags.split(',')
+                        if playbook.only_tags:
+                            only_tags = playbook.only_tags.split(',')
 
                     if 'skip_tags' in serializer.validated_data:
                         if request.user.has_perm('playbook.can_override_skip_tags', playbook):
@@ -64,7 +65,8 @@ class PlaybookViewSet(viewsets.ModelViewSet):
                                 status=status.HTTP_403_FORBIDDEN
                             )
                     else:
-                        skip_tags = playbook.skip_tags.split(',')
+                        if playbook.skip_tags:
+                            skip_tags = playbook.skip_tags.split(',')
 
                     if 'extra_vars' in serializer.validated_data:
                         if request.user.has_perm('playbook.can_override_extra_vars', playbook):
@@ -78,10 +80,11 @@ class PlaybookViewSet(viewsets.ModelViewSet):
                                 status=status.HTTP_403_FORBIDDEN
                             )
                     else:
-                        extra_vars = {}
-                        for var in playbook.extra_vars.split(','):
-                            extra = var.split('=')
-                            extra_vars[extra[0]] = extra[1]
+                        if playbook.extra_vars:
+                            extra_vars = {}
+                            for var in playbook.extra_vars.split(','):
+                                extra = var.split('=')
+                                extra_vars[extra[0]] = extra[1]
 
                     # Launch the playbook
                     task = task_run_playbook.delay(

--- a/requirements/requirements-optionals.txt
+++ b/requirements/requirements-optionals.txt
@@ -1,1 +1,2 @@
-# Optional packages which may be used with REST framework.
+# Optional packages used for plugins
+hvac

--- a/setup.py
+++ b/setup.py
@@ -106,6 +106,11 @@ setup(
         'cyclosible.plugins.storage': [
             's3 = cyclosible.playbook.plugins.storage.s3:S3Plugin',
         ],
+        'cyclosible.plugins.vault': [
+            'password = cyclosible.playbook.plugins.vault.password:PasswordPlugin',
+            'file = cyclosible.playbook.plugins.vault.file:FilePlugin',
+            'hashicorp = cyclosible.playbook.plugins.vault.hashicorp:HashicorpPlugin',
+        ],
     },
 )
 


### PR DESCRIPTION
``` python
# Can be 'password', 'file' or 'hashicorp'.
# The hashicorp plugin will request the password in hashicorp's vault
# Let this variable to None to disable vault password
# Uncomment VAULT_* variables to configure the plugins
# As it's a python file, you can also use os.environ to get the
# value from your environment

VAULT_ENABLED = None
# VAULT_PASSWORD = "XXXXXXXX"
# VAULT_FILE = "/home/<vault_password_path>"
# VAULT_HASHICORP = {
#     'scheme': 'https',
#     'host': 'vault.company.com',
#     'port': 8200,
#     'token': 'xxxxxxxxxxxxxxxxx',
#     'secret_path': 'cycloid/ansible',
#     'secret_field': 'value'
# }
```
